### PR TITLE
call getPath() to get project path

### DIFF
--- a/lib/linter-elixirc.coffee
+++ b/lib/linter-elixirc.coffee
@@ -34,7 +34,7 @@ class LinterElixirc extends Linter
       args.push(path)
 
     build_env = process.env["MIX_ENV"] || "dev"
-    process.env["ERL_LIBS"] = atom.project.path+"/_build/"+build_env+"/lib/"
+    process.env["ERL_LIBS"] = atom.project.getPath()+"/_build/"+build_env+"/lib/"
 
     # options for BufferedProcess, same syntax with child_process.spawn
     options = { cwd: @cwd }


### PR DESCRIPTION
I'm new to atom, but it looks like at some point the api changed and this linter wasn't updated. I adjusted the project path retrieval and now lib resolution is working again.