### PR TITLE
Enable linting files without having _build directory

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -99,8 +99,11 @@ module.exports =
     getDepsPa = (textEditor) ->
       env = if isTestFile(textEditor) then "test" else "dev"
       buildDir = path.join("_build", env, "lib")
-      fs.readdirSync(path.join(projectPath(textEditor), buildDir)).map (item) ->
-        path.join(projectPath(textEditor), buildDir, item, "ebin")
+      try
+        fs.readdirSync(path.join(projectPath(textEditor), buildDir)).map (item) ->
+          path.join(projectPath(textEditor), buildDir, item, "ebin")
+      catch e
+        []
     lintElixirc = (textEditor) =>
       elixircArgs = [
         "--ignore-module-conflict", "--app", "mix", "--app", "ex_unit", "-o", os.tmpDir(),


### PR DESCRIPTION
Allows the linter to work even if the file/project does not have `_build` directory