### PR TITLE
Add language-elixir to package-deps

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -18,7 +18,7 @@ module.exports =
       default: false
 
   activate: ->
-    require('atom-package-deps').install()
+    require('atom-package-deps').install('linter-elixirc')
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.config.observe 'linter-elixirc.elixircPath',
       (elixircPath) =>

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     }
   },
   "package-deps": [
-    "linter"
+    "linter",
+    "language-elixir"
   ],
   "dependencies": {
     "atom-linter": "^4.6.1",


### PR DESCRIPTION
This will automatically install the required language package as it isn't included in a default Atom installation.