### PR TITLE
Cleanup and bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 npm-debug.log
 node_modules
 .github_changelog_generator
+spec/fixtures/proj/_build

--- a/lib/init.js
+++ b/lib/init.js
@@ -290,8 +290,13 @@ const lintElixirc = async (textEditor) => {
 };
 
 const lintMix = async (textEditor) => {
+  const fileText = textEditor.getText();
   const execOpts = await getOpts(textEditor);
   const result = await exec(mixPath, ['compile'], execOpts);
+  if (textEditor.getText() !== fileText) {
+    // File contents have changed since the run was triggered, don't update messages
+    return null;
+  }
   return handleResult(result, textEditor);
 };
 

--- a/lib/init.js
+++ b/lib/init.js
@@ -112,7 +112,7 @@ const parseError = async (toParse, textEditor) => {
     let text;
     let filePath;
     let range;
-    if (reResult[2] !== null) {
+    if (reResult[2] !== undefined) {
       text = `(${reResult[1]}) ${reResult[2]}`;
       filePath = join(projectPath, reResult[3]);
       const fileEditor = findTextEditor(filePath);

--- a/lib/init.js
+++ b/lib/init.js
@@ -128,8 +128,9 @@ const parseError = async (toParse, textEditor) => {
     } else {
       text = `(${reResult[1]}) ${reResult[7]}`;
       filePath = join(projectPath, reResult[5]);
-      if (filePath === textEditor.getPath()) {
-        range = rangeFromLineNumber(textEditor, reResult[6] - 1);
+      const fileEditor = findTextEditor(filePath);
+      if (fileEditor) {
+        range = rangeFromLineNumber(fileEditor, reResult[6] - 1);
       } else {
         range = new Range([reResult[6] - 1, 0], [reResult[6] - 1, 1]);
       }

--- a/lib/init.js
+++ b/lib/init.js
@@ -97,21 +97,35 @@ const parseError = async (toParse, textEditor) => {
   const projectPath = await elixirProjectPath(textEditor);
   let reResult = re.exec(toParse);
   while (reResult !== null) {
+    let text;
+    let filePath;
+    let range;
     if (reResult[2] !== null) {
-      messages.push({
-        type: 'Error',
-        text: `(${reResult[1]}) ${reResult[2]}`,
-        filePath: join(projectPath, reResult[3]),
-        range: rangeFromLineNumber(textEditor, reResult[4] - 1),
-      });
+      text = `(${reResult[1]}) ${reResult[2]}`;
+      filePath = join(projectPath, reResult[3]);
+      if (filePath === textEditor.getPath()) {
+        // If the Error is in the current file, we can get a better range
+        // using rangeFromLineNumber, otherwise generate a 1 character range
+        // that can be updated to a proper range if/when the file is opened.
+        range = rangeFromLineNumber(textEditor, reResult[4] - 1);
+      } else {
+        range = new Range([reResult[4] - 1, 0], [reResult[4] - 1, 1]);
+      }
     } else {
-      messages.push({
-        type: 'Error',
-        text: `(${reResult[1]}) ${reResult[7]}`,
-        filePath: join(projectPath, reResult[5]),
-        range: rangeFromLineNumber(textEditor, reResult[6] - 1),
-      });
+      text = `(${reResult[1]}) ${reResult[7]}`;
+      filePath = join(projectPath, reResult[5]);
+      if (filePath === textEditor.getPath()) {
+        range = rangeFromLineNumber(textEditor, reResult[6] - 1);
+      } else {
+        range = new Range([reResult[6] - 1, 0], [reResult[6] - 1, 1]);
+      }
     }
+    messages.push({
+      type: 'Error',
+      text,
+      filePath,
+      range,
+    });
     reResult = re.exec(toParse);
   }
   return messages;
@@ -135,9 +149,6 @@ const parseWarning = async (toParse, textEditor) => {
     try {
       let range;
       if (filePath === textEditor.getPath()) {
-        // If the Warning is in the current file, we can get a better range
-        // using rangeFromLineNumber, otherwise generate a 1 character range
-        // that can be updated to a proper range if/when the file is opened.
         range = rangeFromLineNumber(textEditor, reResult[3] - 1);
       } else {
         range = new Range([reResult[3] - 1, 0], [reResult[3] - 1, 1]);
@@ -176,9 +187,6 @@ const parseLegacyWarning = async (toParse, textEditor) => {
     try {
       let range;
       if (filePath === textEditor.getPath()) {
-        // If the Warning is in the current file, we can get a better range
-        // using rangeFromLineNumber, otherwise generate a 1 character range
-        // that can be updated to a proper range if/when the file is opened.
         range = rangeFromLineNumber(textEditor, reResult[3] - 1);
       } else {
         range = new Range([reResult[3] - 1, 0], [reResult[3] - 1, 1]);

--- a/lib/init.js
+++ b/lib/init.js
@@ -4,17 +4,6 @@
 import { CompositeDisposable, Range } from 'atom';
 
 export default {
-  config: {
-    elixircPath: { type: 'string', title: 'Elixirc path', default: 'elixirc' },
-    mixPath: { type: 'string', title: 'Mix path', default: 'mix' },
-    forceElixirc: {
-      type: 'boolean',
-      title: 'Always use elixirc',
-      description: 'Activating this will force the plugin to never use ' +
-        '`mix compile` and always use `elixirc`.',
-      default: false,
-    },
-  },
   activate() {
     require('atom-package-deps').install('linter-elixirc');
     this.subscriptions = new CompositeDisposable();

--- a/lib/init.js
+++ b/lib/init.js
@@ -220,7 +220,6 @@ const getOpts = async textEditor => ({
   throwOnStdErr: false,
   stream: 'both',
   allowEmptyStderr: true,
-  env: process.env,
 });
 
 const getDepsPa = async (textEditor) => {

--- a/lib/init.js
+++ b/lib/init.js
@@ -40,34 +40,33 @@ const findElixirProjectPath = async (editorPath) => {
 };
 
 // Memoize the project path per file (traversing is quite expensive)
-const elixirProjectPath = async (textEditor) => {
-  const editorPath = textEditor.getPath();
-  if (elixirProjectPathCache.has(editorPath)) {
-    return elixirProjectPathCache.get(editorPath);
+const elixirProjectPath = async (filePath) => {
+  if (elixirProjectPathCache.has(filePath)) {
+    return elixirProjectPathCache.get(filePath);
   }
-  const projectPath = await findElixirProjectPath(editorPath);
-  elixirProjectPathCache.set(editorPath, projectPath);
+  const projectPath = await findElixirProjectPath(filePath);
+  elixirProjectPathCache.set(filePath, projectPath);
   return projectPath;
 };
 
-const isMixProject = async (textEditor) => {
-  const project = await elixirProjectPath(textEditor);
+const isMixProject = async (filePath) => {
+  const project = await elixirProjectPath(filePath);
   return existsSync(join(project, 'mix.exs'));
 };
 
-const isTestFile = async (textEditor) => {
-  const project = await elixirProjectPath(textEditor);
-  const relativePath = relative(project, textEditor.getPath());
+const isTestFile = async (filePath) => {
+  const project = await elixirProjectPath(filePath);
+  const relativePath = relative(project, filePath);
   // Is the first directory of the relative path "test"?
   return relativePath.split(sep)[0] === 'test';
 };
 
 const isForcedElixirc = () => forceElixirc;
 
-const isExsFile = textEditor => textEditor.getPath().endsWith('.exs');
+const isExsFile = filePath => filePath.endsWith('.exs');
 
-const isPhoenixProject = async (textEditor) => {
-  const project = await elixirProjectPath(textEditor);
+const isPhoenixProject = async (filePath) => {
+  const project = await elixirProjectPath(filePath);
   const mixLockPath = join(project, 'mix.lock');
   try {
     const mixLockContent = readFileSync(mixLockPath, 'utf-8');
@@ -87,7 +86,7 @@ const findTextEditor = (filePath) => {
   return false;
 };
 
-const parseError = async (toParse, textEditor) => {
+const parseError = async (toParse, sourceFilePath) => {
   const messages = [];
   const re = regexp(
     `
@@ -106,7 +105,7 @@ const parseError = async (toParse, textEditor) => {
   `,
     'gm',
   );
-  const projectPath = await elixirProjectPath(textEditor);
+  const projectPath = await elixirProjectPath(sourceFilePath);
   let reResult = re.exec(toParse);
   while (reResult !== null) {
     let text;
@@ -147,7 +146,7 @@ const parseError = async (toParse, textEditor) => {
 };
 
 // Only Elixir 1.3+
-const parseWarning = async (toParse, textEditor) => {
+const parseWarning = async (toParse, sourceFilePath) => {
   const messages = [];
   const re = regexp(
     `
@@ -156,7 +155,7 @@ const parseWarning = async (toParse, textEditor) => {
     `,
     'g',
   );
-  const projectPath = await elixirProjectPath(textEditor);
+  const projectPath = await elixirProjectPath(sourceFilePath);
   let reResult = re.exec(toParse);
 
   while (reResult != null) {
@@ -185,7 +184,7 @@ const parseWarning = async (toParse, textEditor) => {
 };
 
 // Parses warning for elixir 1.2 and below
-const parseLegacyWarning = async (toParse, textEditor) => {
+const parseLegacyWarning = async (toParse, sourceFilePath) => {
   const messages = [];
   const re = regexp(
     `
@@ -196,7 +195,7 @@ const parseLegacyWarning = async (toParse, textEditor) => {
     `,
     'g',
   );
-  const projectPath = await elixirProjectPath(textEditor);
+  const projectPath = await elixirProjectPath(sourceFilePath);
   let reResult = re.exec(toParse);
   while (reResult !== null) {
     const filePath = join(projectPath, reResult[1]);
@@ -223,12 +222,12 @@ const parseLegacyWarning = async (toParse, textEditor) => {
   return messages;
 };
 
-const handleResult = async (compileResult, textEditor) => {
+const handleResult = async (compileResult, filePath) => {
   const resultString = `${compileResult.stdout}\n${compileResult.stderr}`;
   try {
-    const errorStack = await parseError(resultString, textEditor);
-    const warningStack = await parseWarning(resultString, textEditor);
-    const legacyWarningStack = await parseLegacyWarning(resultString, textEditor);
+    const errorStack = await parseError(resultString, filePath);
+    const warningStack = await parseWarning(resultString, filePath);
+    const legacyWarningStack = await parseLegacyWarning(resultString, filePath);
     return errorStack.concat(warningStack).concat(legacyWarningStack)
       .filter(error => error !== null)
       .map(error => error);
@@ -239,17 +238,17 @@ const handleResult = async (compileResult, textEditor) => {
   }
 };
 
-const getOpts = async textEditor => ({
-  cwd: await elixirProjectPath(textEditor),
+const getOpts = async filePath => ({
+  cwd: await elixirProjectPath(filePath),
   throwOnStdErr: false,
   stream: 'both',
   allowEmptyStderr: true,
 });
 
-const getDepsPa = async (textEditor) => {
-  const env = (await isTestFile(textEditor)) ? 'test' : 'dev';
+const getDepsPa = async (filePath) => {
+  const env = (await isTestFile(filePath)) ? 'test' : 'dev';
   const buildDir = join('_build', env, 'lib');
-  const projectPath = await elixirProjectPath(textEditor);
+  const projectPath = await elixirProjectPath(filePath);
   try {
     return readdirSync(join(projectPath, buildDir))
       .map(
@@ -262,6 +261,7 @@ const getDepsPa = async (textEditor) => {
 };
 
 const lintElixirc = async (textEditor) => {
+  const filePath = textEditor.getPath();
   const tempDir = tmp.dirSync({ unsafeCleanup: true });
   const elixircArgs = [
     '--ignore-module-conflict',
@@ -272,14 +272,14 @@ const lintElixirc = async (textEditor) => {
     '-o',
     tempDir.name,
   ];
-  const paDeps = await getDepsPa(textEditor);
+  const paDeps = await getDepsPa(filePath);
   paDeps.forEach((item) => {
     elixircArgs.push('-pa', item);
   });
-  elixircArgs.push(textEditor.getPath());
+  elixircArgs.push(filePath);
 
   const fileText = textEditor.getText();
-  const execOpts = await getOpts(textEditor);
+  const execOpts = await getOpts(filePath);
   const result = await exec(elixircPath, elixircArgs, execOpts);
   // Cleanup the temp dir
   tempDir.removeCallback();
@@ -287,18 +287,19 @@ const lintElixirc = async (textEditor) => {
     // File contents have changed since the run was triggered, don't update messages
     return null;
   }
-  return handleResult(result, textEditor);
+  return handleResult(result, filePath);
 };
 
 const lintMix = async (textEditor) => {
+  const filePath = textEditor.getPath();
   const fileText = textEditor.getText();
-  const execOpts = await getOpts(textEditor);
+  const execOpts = await getOpts(filePath);
   const result = await exec(mixPath, ['compile'], execOpts);
   if (textEditor.getText() !== fileText) {
     // File contents have changed since the run was triggered, don't update messages
     return null;
   }
-  return handleResult(result, textEditor);
+  return handleResult(result, filePath);
 };
 
 export default {
@@ -334,11 +335,12 @@ export default {
       lintOnFly: false,
       name: 'Elixir',
       async lint(textEditor) {
+        const filePath = textEditor.getPath();
         if (
           isForcedElixirc() ||
-            !(await isMixProject(textEditor)) ||
-            isExsFile(textEditor) ||
-            (await isPhoenixProject(textEditor))
+            !(await isMixProject(filePath)) ||
+            isExsFile(filePath) ||
+            (await isPhoenixProject(filePath))
         ) {
           return lintElixirc(textEditor);
         }

--- a/lib/init.js
+++ b/lib/init.js
@@ -1,5 +1,7 @@
 'use babel';
-import { BufferedProcess, CompositeDisposable, Range } from 'atom';
+
+// eslint-disable-next-line import/no-extraneous-dependencies, import/extensions
+import { CompositeDisposable, Range } from 'atom';
 
 export default {
   config: {
@@ -10,37 +12,36 @@ export default {
       title: 'Always use elixirc',
       description: 'Activating this will force the plugin to never use ' +
         '`mix compile` and always use `elixirc`.',
-      default: false
-    }
+      default: false,
+    },
   },
   activate() {
     require('atom-package-deps').install('linter-elixirc');
     this.subscriptions = new CompositeDisposable();
     this.subscriptions.add(
-      atom.config.observe('linter-elixirc.elixircPath', elixircPath => {
-        return this.elixircPath = elixircPath;
-      })
+      atom.config.observe('linter-elixirc.elixircPath', (value) => {
+        this.elixircPath = value;
+      }),
     );
     this.subscriptions.add(
-      atom.config.observe('linter-elixirc.mixPath', mixPath => {
-        return this.mixPath = mixPath;
-      })
+      atom.config.observe('linter-elixirc.mixPath', (value) => {
+        this.mixPath = value;
+      }),
     );
     return this.subscriptions.add(
-      atom.config.observe('linter-elixirc.forceElixirc', forceElixirc => {
-        return this.forceElixirc = forceElixirc;
-      })
+      atom.config.observe('linter-elixirc.forceElixirc', (value) => {
+        this.forceElixirc = value;
+      }),
     );
   },
   deactivate() {
     return this.subscriptions.dispose();
   },
   provideLinter() {
-    let provider;
-    let helpers = require('atom-linter');
-    let os = require('os');
-    let fs = require('fs');
-    let path = require('path');
+    const helpers = require('atom-linter');
+    const os = require('os');
+    const fs = require('fs');
+    const path = require('path');
 
     function regexp(string, flags) {
       return new RegExp(
@@ -48,16 +49,16 @@ export default {
           .replace(/\\ /gm, 'randomstring123')
           .replace(/\s/gm, '')
           .replace(/randomstring123/gm, '\\ '),
-        flags
+        flags,
       );
     }
 
     // find elixir project in the file path by locating mix.exs, otherwise
     // fallback to project path or file path
-    const findElixirProjectPath = function(editorPath) {
+    const findElixirProjectPath = (editorPath) => {
       let prevPath;
       let currPath = editorPath;
-      while (prevPath != currPath) {
+      while (prevPath !== currPath) {
         if (fs.existsSync(path.join(currPath, 'mix.exs'))) return currPath;
         prevPath = currPath;
         currPath = path.normalize(path.resolve(currPath, '..'));
@@ -71,61 +72,58 @@ export default {
 
     const elixirProjectPathCache = {};
     // memoize the project path per file (traversing is quite expensive)
-    const elixirProjectPath = function(textEditor) {
+    const elixirProjectPath = (textEditor) => {
       const editorPath = textEditor.getPath();
-      if (elixirProjectPathCache[editorPath])
-        return elixirProjectPathCache[editorPath];
+      if (elixirProjectPathCache[editorPath]) { return elixirProjectPathCache[editorPath]; }
       const projectPath = findElixirProjectPath(editorPath);
       elixirProjectPathCache[editorPath] = projectPath;
       return projectPath;
     };
 
-    let isMixProject = function(textEditor) {
-      let project = elixirProjectPath(textEditor);
+    const isMixProject = (textEditor) => {
+      const project = elixirProjectPath(textEditor);
       return fs.existsSync(path.join(project, 'mix.exs'));
     };
 
-    let isTestFile = function(textEditor) {
-      let project = elixirProjectPath(textEditor);
-      let relativePath = path.relative(project, textEditor.getPath());
+    const isTestFile = (textEditor) => {
+      const project = elixirProjectPath(textEditor);
+      const relativePath = path.relative(project, textEditor.getPath());
       return relativePath.split(path.sep)[0] === 'test';
     };
 
-    let isForcedElixirc = () => {
-      return this.forceElixirc;
-    };
+    const isForcedElixirc = () => this.forceElixirc;
 
-    let isExsFile = textEditor => textEditor.getPath().endsWith('.exs');
+    const isExsFile = textEditor => textEditor.getPath().endsWith('.exs');
 
-    let isPhoenixProject = function(textEditor) {
-      let project = elixirProjectPath(textEditor);
-      let mixLockPath = path.join(project, 'mix.lock');
+    const isPhoenixProject = (textEditor) => {
+      const project = elixirProjectPath(textEditor);
+      const mixLockPath = path.join(project, 'mix.lock');
       try {
-        let mixLockContent = fs.readFileSync(mixLockPath, 'utf-8');
+        const mixLockContent = fs.readFileSync(mixLockPath, 'utf-8');
         return mixLockContent.indexOf('"phoenix"') > 0;
       } catch (error) {
         return false;
       }
     };
 
-    let parseError = function(toParse, textEditor) {
-      let ret = [];
+    const parseError = (toParse, textEditor) => {
+      const ret = [];
       const re = regexp(
         `
         \\*\\*[\\ ]+
-        \\((\\w+)\\)                   ${'' /* 1 - (TypeOfError)*/}
-        [\\ ](?:                       ${'' /* Two message formats.... mode one*/}
-          ([\\w\\ ]+)                  ${'' /* 2 - Message*/}
-          [\\r\\n]{1,2}.+[\\r\\n]{1,2} ${'' /* Internal elixir code*/}
-          [\\ ]+(.+)                   ${'' /* 3 - File*/}
-          :(\\d+):                     ${'' /* 4 - Line*/}
-        |                              ${'' /* # Or... mode two*/}
-          (.+)                         ${'' /* 5 - File*/}
-          :(\\d+):                     ${'' /* 6 - Line*/}
-          [\\ ](.+)                    ${'' /* 7 - Message*/}
+        \\((\\w+)\\)                   ${''}
+        [\\ ](?:                       ${''}
+          ([\\w\\ ]+)                  ${''}
+          [\\r\\n]{1,2}.+[\\r\\n]{1,2} ${''}
+          [\\ ]+(.+)                   ${''}
+          :(\\d+):                     ${''}
+        |                              ${''}
+          (.+)                         ${''}
+          :(\\d+):                     ${''}
+          [\\ ](.+)                    ${''}
         )
       `,
-        'gm'
+        'gm',
       );
       let reResult = re.exec(toParse);
       while (reResult != null) {
@@ -134,14 +132,14 @@ export default {
             type: 'Error',
             text: `(${reResult[1]}) ${reResult[2]}`,
             filePath: path.join(elixirProjectPath(textEditor), reResult[3]),
-            range: helpers.rangeFromLineNumber(textEditor, reResult[4] - 1)
+            range: helpers.rangeFromLineNumber(textEditor, reResult[4] - 1),
           });
         } else {
           ret.push({
             type: 'Error',
             text: `(${reResult[1]}) ${reResult[7]}`,
             filePath: path.join(elixirProjectPath(textEditor), reResult[5]),
-            range: helpers.rangeFromLineNumber(textEditor, reResult[6] - 1)
+            range: helpers.rangeFromLineNumber(textEditor, reResult[6] - 1),
           });
         }
         reResult = re.exec(toParse);
@@ -150,14 +148,14 @@ export default {
     };
 
     // only elixir 1.3+
-    let parseWarning = function(toParse, textEditor) {
-      let ret = [];
-      let re = regexp(
+    const parseWarning = (toParse, textEditor) => {
+      const ret = [];
+      const re = regexp(
         `
-        warning:\\ (.*)\\n ${'' /* # warning */}
-        \\ \\ (.*):([0-9]+) ${'' /*# file and file number */}
+        warning:\\ (.*)\\n ${''}
+        \\ \\ (.*):([0-9]+) ${''}
         `,
-        'g'
+        'g',
       );
       let reResult = re.exec(toParse);
 
@@ -173,9 +171,10 @@ export default {
             // if the compiler returned warnings or errors of other files,
             // it would thus frequently blow up and return no errors/warnings
             // at all
-            range: new Range([ reResult[3] - 1, 0 ], [ reResult[3] - 1, 1 ])
+            range: new Range([reResult[3] - 1, 0], [reResult[3] - 1, 1]),
           });
         } catch (Error) {
+          // eslint-disable-next-line no-console
           console.error('linter-elixirc:', Error);
         }
         reResult = re.exec(toParse);
@@ -184,16 +183,16 @@ export default {
     };
 
     // parses warning for elixir 1.2 and below
-    let parseLegacyWarning = function(toParse, textEditor) {
-      let ret = [];
-      let re = regexp(
+    const parseLegacyWarning = (toParse, textEditor) => {
+      const ret = [];
+      const re = regexp(
         `
-        ([^:\\n]*)   ${'' /* 1 - File name */}
-        :(\\d+)      ${'' /* 2 - Line */}
+        ([^:\\n]*)   ${''}
+        :(\\d+)      ${''}
         :\\ warning
-        :\\ (.*)     ${'' /* 3 - Message */}
+        :\\ (.*)     ${''}
         `,
-        'g'
+        'g',
       );
       let reResult = re.exec(toParse);
       while (reResult != null) {
@@ -202,9 +201,10 @@ export default {
             type: 'Warning',
             text: reResult[3],
             filePath: path.join(elixirProjectPath(textEditor), reResult[1]),
-            range: new Range([ reResult[3] - 1, 0 ], [ reResult[3] - 1, 1 ])
+            range: new Range([reResult[3] - 1, 0], [reResult[3] - 1, 1]),
           });
         } catch (Error) {
+          // eslint-disable-next-line no-console
           console.error('linter-elixirc:', Error);
         }
         reResult = re.exec(toParse);
@@ -212,63 +212,59 @@ export default {
       return ret;
     };
 
-    let handleResult = textEditor => function(compileResult) {
-      let resultString = compileResult['stdout'] +
-        '\n' +
-        compileResult['stderr'];
+    const handleResult = textEditor => (compileResult) => {
+      const resultString = `${compileResult.stdout}\n${compileResult.stderr}`;
       try {
-        let errorStack = parseError(resultString, textEditor);
-        let warningStack = parseWarning(resultString, textEditor);
-        let legacyWarningStack = parseLegacyWarning(resultString, textEditor);
+        const errorStack = parseError(resultString, textEditor);
+        const warningStack = parseWarning(resultString, textEditor);
+        const legacyWarningStack = parseLegacyWarning(resultString, textEditor);
         return Array
           .from(errorStack.concat(warningStack))
           .filter(error => error != null)
           .map(error => error);
       } catch (Error) {
+        // eslint-disable-next-line no-console
         console.error('linter-elixirc:', Error);
         return []; // error in different file, just suppress
       }
     };
 
-    let getOpts = function(textEditor) {
-      let opts;
-      return opts = {
-        cwd: elixirProjectPath(textEditor),
-        throwOnStdErr: false,
-        stream: 'both',
-        allowEmptyStderr: true,
-        env: process.env
-      };
-    };
+    const getOpts = textEditor => ({
+      cwd: elixirProjectPath(textEditor),
+      throwOnStdErr: false,
+      stream: 'both',
+      allowEmptyStderr: true,
+      env: process.env,
+    });
 
-    let getDepsPa = function(textEditor) {
-      let env = isTestFile(textEditor) ? 'test' : 'dev';
-      let buildDir = path.join('_build', env, 'lib');
+    const getDepsPa = (textEditor) => {
+      const env = isTestFile(textEditor) ? 'test' : 'dev';
+      const buildDir = path.join('_build', env, 'lib');
       try {
         return fs
           .readdirSync(path.join(elixirProjectPath(textEditor), buildDir))
           .map(
             item =>
-              path.join(elixirProjectPath(textEditor), buildDir, item, 'ebin')
+              path.join(elixirProjectPath(textEditor), buildDir, item, 'ebin'),
           );
       } catch (e) {
         return [];
       }
     };
 
-    let lintElixirc = textEditor => {
-      let elixircArgs = [
+    const lintElixirc = (textEditor) => {
+      const elixircArgs = [
         '--ignore-module-conflict',
         '--app',
         'mix',
         '--app',
         'ex_unit',
         '-o',
-        os.tmpDir()
+        os.tmpDir(),
       ];
-      for (let item of Array.from(getDepsPa(textEditor))) {
+      Array.from(getDepsPa(textEditor)).forEach((item) => {
         elixircArgs.push('-pa', item);
-      }
+      });
       elixircArgs.push(textEditor.getPath());
 
       return helpers
@@ -276,14 +272,12 @@ export default {
         .then(handleResult(textEditor));
     };
 
-    let lintMix = textEditor => {
-      return helpers
-        .exec(this.mixPath, [ 'compile' ], getOpts(textEditor))
+    const lintMix = textEditor => helpers
+        .exec(this.mixPath, ['compile'], getOpts(textEditor))
         .then(handleResult(textEditor));
-    };
 
-    return provider = {
-      grammarScopes: [ 'source.elixir' ],
+    return {
+      grammarScopes: ['source.elixir'],
       scope: 'project',
       lintOnFly: false,
       name: 'Elixir',
@@ -295,10 +289,9 @@ export default {
             isPhoenixProject(textEditor)
         ) {
           return lintElixirc(textEditor);
-        } else {
-          return lintMix(textEditor);
         }
-      }
+        return lintMix(textEditor);
+      },
     };
-  }
-}
+  },
+};

--- a/lib/init.js
+++ b/lib/init.js
@@ -2,6 +2,248 @@
 
 // eslint-disable-next-line import/no-extraneous-dependencies, import/extensions
 import { CompositeDisposable, Range } from 'atom';
+import { findCachedAsync, rangeFromLineNumber, exec } from 'atom-linter';
+import { dirname, join, relative, sep } from 'path';
+import { existsSync, readFileSync, readdirSync } from 'fs';
+import { tmpDir } from 'os';
+
+// Internal values
+const elixirProjectPathCache = {};
+let elixircPath;
+let mixPath;
+let forceElixirc;
+
+function regexp(string, flags) {
+  return new RegExp(
+    string
+      .replace(/\\ /gm, 'randomstring123')
+      .replace(/\s/gm, '')
+      .replace(/randomstring123/gm, '\\ '),
+    flags,
+  );
+}
+
+// find elixir project in the file path by locating mix.exs, otherwise
+// fallback to project path or file path
+const findElixirProjectPath = async (editorPath) => {
+  const editorDir = dirname(editorPath);
+  const mixexsPath = await findCachedAsync(editorDir, 'mix.exs');
+  if (mixexsPath !== null) {
+    return mixexsPath;
+  }
+  const projPath = atom.project.relativizePath(editorPath)[0];
+  if (projPath !== null) {
+    return projPath;
+  }
+  return editorDir;
+};
+
+// memoize the project path per file (traversing is quite expensive)
+const elixirProjectPath = async (textEditor) => {
+  const editorPath = textEditor.getPath();
+  if (elixirProjectPathCache[editorPath]) { return elixirProjectPathCache[editorPath]; }
+  const projectPath = await findElixirProjectPath(editorPath);
+  elixirProjectPathCache[editorPath] = projectPath;
+  return projectPath;
+};
+
+const isMixProject = async (textEditor) => {
+  const project = await elixirProjectPath(textEditor);
+  return existsSync(join(project, 'mix.exs'));
+};
+
+const isTestFile = async (textEditor) => {
+  const project = await elixirProjectPath(textEditor);
+  const relativePath = relative(project, textEditor.getPath());
+  return relativePath.split(sep)[0] === 'test';
+};
+
+const isForcedElixirc = () => forceElixirc;
+
+const isExsFile = textEditor => textEditor.getPath().endsWith('.exs');
+
+const isPhoenixProject = async (textEditor) => {
+  const project = await elixirProjectPath(textEditor);
+  const mixLockPath = join(project, 'mix.lock');
+  try {
+    const mixLockContent = readFileSync(mixLockPath, 'utf-8');
+    return mixLockContent.indexOf('"phoenix"') > 0;
+  } catch (error) {
+    return false;
+  }
+};
+
+const parseError = async (toParse, textEditor) => {
+  const ret = [];
+  const re = regexp(
+    `
+    \\*\\*[\\ ]+
+    \\((\\w+)\\)                   ${''}
+    [\\ ](?:                       ${''}
+      ([\\w\\ ]+)                  ${''}
+      [\\r\\n]{1,2}.+[\\r\\n]{1,2} ${''}
+      [\\ ]+(.+)                   ${''}
+      :(\\d+):                     ${''}
+    |                              ${''}
+      (.+)                         ${''}
+      :(\\d+):                     ${''}
+      [\\ ](.+)                    ${''}
+    )
+  `,
+    'gm',
+  );
+  const projectPath = await elixirProjectPath(textEditor);
+  let reResult = re.exec(toParse);
+  while (reResult != null) {
+    if (reResult[2] != null) {
+      ret.push({
+        type: 'Error',
+        text: `(${reResult[1]}) ${reResult[2]}`,
+        filePath: join(projectPath, reResult[3]),
+        range: rangeFromLineNumber(textEditor, reResult[4] - 1),
+      });
+    } else {
+      ret.push({
+        type: 'Error',
+        text: `(${reResult[1]}) ${reResult[7]}`,
+        filePath: join(projectPath, reResult[5]),
+        range: rangeFromLineNumber(textEditor, reResult[6] - 1),
+      });
+    }
+    reResult = re.exec(toParse);
+  }
+  return ret;
+};
+
+// only elixir 1.3+
+const parseWarning = async (toParse, textEditor) => {
+  const ret = [];
+  const re = regexp(
+    `
+    warning:\\ (.*)\\n ${''}
+    \\ \\ (.*):([0-9]+) ${''}
+    `,
+    'g',
+  );
+  const projectPath = await elixirProjectPath(textEditor);
+  let reResult = re.exec(toParse);
+
+  while (reResult != null) {
+    try {
+      ret.push({
+        type: 'Warning',
+        text: reResult[1],
+        filePath: join(projectPath, reResult[2]),
+        // use range, this because the previous method of getting a range
+        // used the current buffer that is open in the texteditor, and it
+        // blows up if the line number is larger than the current file
+        // if the compiler returned warnings or errors of other files,
+        // it would thus frequently blow up and return no errors/warnings
+        // at all
+        range: new Range([reResult[3] - 1, 0], [reResult[3] - 1, 1]),
+      });
+    } catch (Error) {
+      // eslint-disable-next-line no-console
+      console.error('linter-elixirc:', Error);
+    }
+    reResult = re.exec(toParse);
+  }
+  return ret;
+};
+
+// parses warning for elixir 1.2 and below
+const parseLegacyWarning = async (toParse, textEditor) => {
+  const ret = [];
+  const re = regexp(
+    `
+    ([^:\\n]*)   ${''}
+    :(\\d+)      ${''}
+    :\\ warning
+    :\\ (.*)     ${''}
+    `,
+    'g',
+  );
+  const projectPath = await elixirProjectPath(textEditor);
+  let reResult = re.exec(toParse);
+  while (reResult != null) {
+    try {
+      ret.push({
+        type: 'Warning',
+        text: reResult[3],
+        filePath: join(projectPath, reResult[1]),
+        range: new Range([reResult[3] - 1, 0], [reResult[3] - 1, 1]),
+      });
+    } catch (Error) {
+      // eslint-disable-next-line no-console
+      console.error('linter-elixirc:', Error);
+    }
+    reResult = re.exec(toParse);
+  }
+  return ret;
+};
+
+const handleResult = async textEditor => async (compileResult) => {
+  const resultString = `${compileResult.stdout}\n${compileResult.stderr}`;
+  try {
+    const errorStack = await parseError(resultString, textEditor);
+    const warningStack = await parseWarning(resultString, textEditor);
+    const legacyWarningStack = await parseLegacyWarning(resultString, textEditor);
+    return Array
+      .from(errorStack.concat(warningStack).concat(legacyWarningStack))
+      .filter(error => error != null)
+      .map(error => error);
+  } catch (Error) {
+    // eslint-disable-next-line no-console
+    console.error('linter-elixirc:', Error);
+    return []; // error in different file, just suppress
+  }
+};
+
+const getOpts = async textEditor => ({
+  cwd: await elixirProjectPath(textEditor),
+  throwOnStdErr: false,
+  stream: 'both',
+  allowEmptyStderr: true,
+  env: process.env,
+});
+
+const getDepsPa = async (textEditor) => {
+  const env = await isTestFile(textEditor) ? 'test' : 'dev';
+  const buildDir = join('_build', env, 'lib');
+  const projectPath = await elixirProjectPath(textEditor);
+  try {
+    return readdirSync(join(projectPath, buildDir))
+      .map(
+        item =>
+          join(projectPath, buildDir, item, 'ebin'),
+      );
+  } catch (e) {
+    return [];
+  }
+};
+
+const lintElixirc = async (textEditor) => {
+  const elixircArgs = [
+    '--ignore-module-conflict',
+    '--app',
+    'mix',
+    '--app',
+    'ex_unit',
+    '-o',
+    tmpDir(),
+  ];
+  Array.from(await getDepsPa(textEditor)).forEach((item) => {
+    elixircArgs.push('-pa', item);
+  });
+  elixircArgs.push(textEditor.getPath());
+
+  return exec(elixircPath, elixircArgs, await getOpts(textEditor))
+    .then(handleResult(textEditor));
+};
+
+const lintMix = async textEditor =>
+  exec(mixPath, ['compile'], await getOpts(textEditor))
+    .then(handleResult(textEditor));
 
 export default {
   activate() {
@@ -9,273 +251,37 @@ export default {
     this.subscriptions = new CompositeDisposable();
     this.subscriptions.add(
       atom.config.observe('linter-elixirc.elixircPath', (value) => {
-        this.elixircPath = value;
+        elixircPath = value;
       }),
     );
     this.subscriptions.add(
       atom.config.observe('linter-elixirc.mixPath', (value) => {
-        this.mixPath = value;
+        mixPath = value;
       }),
     );
     return this.subscriptions.add(
       atom.config.observe('linter-elixirc.forceElixirc', (value) => {
-        this.forceElixirc = value;
+        forceElixirc = value;
       }),
     );
   },
+
   deactivate() {
-    return this.subscriptions.dispose();
+    this.subscriptions.dispose();
   },
+
   provideLinter() {
-    const helpers = require('atom-linter');
-    const os = require('os');
-    const fs = require('fs');
-    const path = require('path');
-
-    function regexp(string, flags) {
-      return new RegExp(
-        string
-          .replace(/\\ /gm, 'randomstring123')
-          .replace(/\s/gm, '')
-          .replace(/randomstring123/gm, '\\ '),
-        flags,
-      );
-    }
-
-    // find elixir project in the file path by locating mix.exs, otherwise
-    // fallback to project path or file path
-    const findElixirProjectPath = (editorPath) => {
-      let prevPath;
-      let currPath = editorPath;
-      while (prevPath !== currPath) {
-        if (fs.existsSync(path.join(currPath, 'mix.exs'))) return currPath;
-        prevPath = currPath;
-        currPath = path.normalize(path.resolve(currPath, '..'));
-      }
-      const projPath = atom.project.relativizePath(editorPath)[0];
-      if (projPath != null) {
-        return projPath;
-      }
-      return path.dirname(editorPath);
-    };
-
-    const elixirProjectPathCache = {};
-    // memoize the project path per file (traversing is quite expensive)
-    const elixirProjectPath = (textEditor) => {
-      const editorPath = textEditor.getPath();
-      if (elixirProjectPathCache[editorPath]) { return elixirProjectPathCache[editorPath]; }
-      const projectPath = findElixirProjectPath(editorPath);
-      elixirProjectPathCache[editorPath] = projectPath;
-      return projectPath;
-    };
-
-    const isMixProject = (textEditor) => {
-      const project = elixirProjectPath(textEditor);
-      return fs.existsSync(path.join(project, 'mix.exs'));
-    };
-
-    const isTestFile = (textEditor) => {
-      const project = elixirProjectPath(textEditor);
-      const relativePath = path.relative(project, textEditor.getPath());
-      return relativePath.split(path.sep)[0] === 'test';
-    };
-
-    const isForcedElixirc = () => this.forceElixirc;
-
-    const isExsFile = textEditor => textEditor.getPath().endsWith('.exs');
-
-    const isPhoenixProject = (textEditor) => {
-      const project = elixirProjectPath(textEditor);
-      const mixLockPath = path.join(project, 'mix.lock');
-      try {
-        const mixLockContent = fs.readFileSync(mixLockPath, 'utf-8');
-        return mixLockContent.indexOf('"phoenix"') > 0;
-      } catch (error) {
-        return false;
-      }
-    };
-
-    const parseError = (toParse, textEditor) => {
-      const ret = [];
-      const re = regexp(
-        `
-        \\*\\*[\\ ]+
-        \\((\\w+)\\)                   ${''}
-        [\\ ](?:                       ${''}
-          ([\\w\\ ]+)                  ${''}
-          [\\r\\n]{1,2}.+[\\r\\n]{1,2} ${''}
-          [\\ ]+(.+)                   ${''}
-          :(\\d+):                     ${''}
-        |                              ${''}
-          (.+)                         ${''}
-          :(\\d+):                     ${''}
-          [\\ ](.+)                    ${''}
-        )
-      `,
-        'gm',
-      );
-      let reResult = re.exec(toParse);
-      while (reResult != null) {
-        if (reResult[2] != null) {
-          ret.push({
-            type: 'Error',
-            text: `(${reResult[1]}) ${reResult[2]}`,
-            filePath: path.join(elixirProjectPath(textEditor), reResult[3]),
-            range: helpers.rangeFromLineNumber(textEditor, reResult[4] - 1),
-          });
-        } else {
-          ret.push({
-            type: 'Error',
-            text: `(${reResult[1]}) ${reResult[7]}`,
-            filePath: path.join(elixirProjectPath(textEditor), reResult[5]),
-            range: helpers.rangeFromLineNumber(textEditor, reResult[6] - 1),
-          });
-        }
-        reResult = re.exec(toParse);
-      }
-      return ret;
-    };
-
-    // only elixir 1.3+
-    const parseWarning = (toParse, textEditor) => {
-      const ret = [];
-      const re = regexp(
-        `
-        warning:\\ (.*)\\n ${''}
-        \\ \\ (.*):([0-9]+) ${''}
-        `,
-        'g',
-      );
-      let reResult = re.exec(toParse);
-
-      while (reResult != null) {
-        try {
-          ret.push({
-            type: 'Warning',
-            text: reResult[1],
-            filePath: path.join(elixirProjectPath(textEditor), reResult[2]),
-            // use range, this because the previous method of getting a range
-            // used the current buffer that is open in the texteditor, and it
-            // blows up if the line number is larger than the current file
-            // if the compiler returned warnings or errors of other files,
-            // it would thus frequently blow up and return no errors/warnings
-            // at all
-            range: new Range([reResult[3] - 1, 0], [reResult[3] - 1, 1]),
-          });
-        } catch (Error) {
-          // eslint-disable-next-line no-console
-          console.error('linter-elixirc:', Error);
-        }
-        reResult = re.exec(toParse);
-      }
-      return ret;
-    };
-
-    // parses warning for elixir 1.2 and below
-    const parseLegacyWarning = (toParse, textEditor) => {
-      const ret = [];
-      const re = regexp(
-        `
-        ([^:\\n]*)   ${''}
-        :(\\d+)      ${''}
-        :\\ warning
-        :\\ (.*)     ${''}
-        `,
-        'g',
-      );
-      let reResult = re.exec(toParse);
-      while (reResult != null) {
-        try {
-          ret.push({
-            type: 'Warning',
-            text: reResult[3],
-            filePath: path.join(elixirProjectPath(textEditor), reResult[1]),
-            range: new Range([reResult[3] - 1, 0], [reResult[3] - 1, 1]),
-          });
-        } catch (Error) {
-          // eslint-disable-next-line no-console
-          console.error('linter-elixirc:', Error);
-        }
-        reResult = re.exec(toParse);
-      }
-      return ret;
-    };
-
-    const handleResult = textEditor => (compileResult) => {
-      const resultString = `${compileResult.stdout}\n${compileResult.stderr}`;
-      try {
-        const errorStack = parseError(resultString, textEditor);
-        const warningStack = parseWarning(resultString, textEditor);
-        const legacyWarningStack = parseLegacyWarning(resultString, textEditor);
-        return Array
-          .from(errorStack.concat(warningStack).concat(legacyWarningStack))
-          .filter(error => error != null)
-          .map(error => error);
-      } catch (Error) {
-        // eslint-disable-next-line no-console
-        console.error('linter-elixirc:', Error);
-        return []; // error in different file, just suppress
-      }
-    };
-
-    const getOpts = textEditor => ({
-      cwd: elixirProjectPath(textEditor),
-      throwOnStdErr: false,
-      stream: 'both',
-      allowEmptyStderr: true,
-      env: process.env,
-    });
-
-    const getDepsPa = (textEditor) => {
-      const env = isTestFile(textEditor) ? 'test' : 'dev';
-      const buildDir = path.join('_build', env, 'lib');
-      try {
-        return fs
-          .readdirSync(path.join(elixirProjectPath(textEditor), buildDir))
-          .map(
-            item =>
-              path.join(elixirProjectPath(textEditor), buildDir, item, 'ebin'),
-          );
-      } catch (e) {
-        return [];
-      }
-    };
-
-    const lintElixirc = (textEditor) => {
-      const elixircArgs = [
-        '--ignore-module-conflict',
-        '--app',
-        'mix',
-        '--app',
-        'ex_unit',
-        '-o',
-        os.tmpDir(),
-      ];
-      Array.from(getDepsPa(textEditor)).forEach((item) => {
-        elixircArgs.push('-pa', item);
-      });
-      elixircArgs.push(textEditor.getPath());
-
-      return helpers
-        .exec(this.elixircPath, elixircArgs, getOpts(textEditor))
-        .then(handleResult(textEditor));
-    };
-
-    const lintMix = textEditor => helpers
-        .exec(this.mixPath, ['compile'], getOpts(textEditor))
-        .then(handleResult(textEditor));
-
     return {
       grammarScopes: ['source.elixir'],
       scope: 'project',
       lintOnFly: false,
       name: 'Elixir',
-      lint(textEditor) {
+      async lint(textEditor) {
         if (
           isForcedElixirc() ||
-            !isMixProject(textEditor) ||
+            !(await isMixProject(textEditor)) ||
             isExsFile(textEditor) ||
-            isPhoenixProject(textEditor)
+            await isPhoenixProject(textEditor)
         ) {
           return lintElixirc(textEditor);
         }

--- a/lib/init.js
+++ b/lib/init.js
@@ -76,7 +76,7 @@ const isPhoenixProject = async (textEditor) => {
 };
 
 const parseError = async (toParse, textEditor) => {
-  const ret = [];
+  const messages = [];
   const re = regexp(
     `
     \\*\\*[\\ ]+
@@ -96,16 +96,16 @@ const parseError = async (toParse, textEditor) => {
   );
   const projectPath = await elixirProjectPath(textEditor);
   let reResult = re.exec(toParse);
-  while (reResult != null) {
-    if (reResult[2] != null) {
-      ret.push({
+  while (reResult !== null) {
+    if (reResult[2] !== null) {
+      messages.push({
         type: 'Error',
         text: `(${reResult[1]}) ${reResult[2]}`,
         filePath: join(projectPath, reResult[3]),
         range: rangeFromLineNumber(textEditor, reResult[4] - 1),
       });
     } else {
-      ret.push({
+      messages.push({
         type: 'Error',
         text: `(${reResult[1]}) ${reResult[7]}`,
         filePath: join(projectPath, reResult[5]),
@@ -114,12 +114,12 @@ const parseError = async (toParse, textEditor) => {
     }
     reResult = re.exec(toParse);
   }
-  return ret;
+  return messages;
 };
 
-// only elixir 1.3+
+// Only Elixir 1.3+
 const parseWarning = async (toParse, textEditor) => {
-  const ret = [];
+  const messages = [];
   const re = regexp(
     `
     warning:\\ (.*)\\n ${''}
@@ -131,18 +131,22 @@ const parseWarning = async (toParse, textEditor) => {
   let reResult = re.exec(toParse);
 
   while (reResult != null) {
+    const filePath = join(projectPath, reResult[2]);
     try {
-      ret.push({
+      let range;
+      if (filePath === textEditor.getPath()) {
+        // If the Warning is in the current file, we can get a better range
+        // using rangeFromLineNumber, otherwise generate a 1 character range
+        // that can be updated to a proper range if/when the file is opened.
+        range = rangeFromLineNumber(textEditor, reResult[3] - 1);
+      } else {
+        range = new Range([reResult[3] - 1, 0], [reResult[3] - 1, 1]);
+      }
+      messages.push({
         type: 'Warning',
         text: reResult[1],
-        filePath: join(projectPath, reResult[2]),
-        // use range, this because the previous method of getting a range
-        // used the current buffer that is open in the texteditor, and it
-        // blows up if the line number is larger than the current file
-        // if the compiler returned warnings or errors of other files,
-        // it would thus frequently blow up and return no errors/warnings
-        // at all
-        range: new Range([reResult[3] - 1, 0], [reResult[3] - 1, 1]),
+        filePath,
+        range,
       });
     } catch (Error) {
       // eslint-disable-next-line no-console
@@ -150,12 +154,12 @@ const parseWarning = async (toParse, textEditor) => {
     }
     reResult = re.exec(toParse);
   }
-  return ret;
+  return messages;
 };
 
-// parses warning for elixir 1.2 and below
+// Parses warning for elixir 1.2 and below
 const parseLegacyWarning = async (toParse, textEditor) => {
-  const ret = [];
+  const messages = [];
   const re = regexp(
     `
     ([^:\\n]*)   ${''}
@@ -167,13 +171,23 @@ const parseLegacyWarning = async (toParse, textEditor) => {
   );
   const projectPath = await elixirProjectPath(textEditor);
   let reResult = re.exec(toParse);
-  while (reResult != null) {
+  while (reResult !== null) {
+    const filePath = join(projectPath, reResult[1]);
     try {
-      ret.push({
+      let range;
+      if (filePath === textEditor.getPath()) {
+        // If the Warning is in the current file, we can get a better range
+        // using rangeFromLineNumber, otherwise generate a 1 character range
+        // that can be updated to a proper range if/when the file is opened.
+        range = rangeFromLineNumber(textEditor, reResult[3] - 1);
+      } else {
+        range = new Range([reResult[3] - 1, 0], [reResult[3] - 1, 1]);
+      }
+      messages.push({
         type: 'Warning',
         text: reResult[3],
-        filePath: join(projectPath, reResult[1]),
-        range: new Range([reResult[3] - 1, 0], [reResult[3] - 1, 1]),
+        filePath,
+        range,
       });
     } catch (Error) {
       // eslint-disable-next-line no-console
@@ -181,7 +195,7 @@ const parseLegacyWarning = async (toParse, textEditor) => {
     }
     reResult = re.exec(toParse);
   }
-  return ret;
+  return messages;
 };
 
 const handleResult = async (compileResult, textEditor) => {

--- a/lib/init.js
+++ b/lib/init.js
@@ -246,7 +246,7 @@ const getOpts = async textEditor => ({
 });
 
 const getDepsPa = async (textEditor) => {
-  const env = await isTestFile(textEditor) ? 'test' : 'dev';
+  const env = (await isTestFile(textEditor)) ? 'test' : 'dev';
   const buildDir = join('_build', env, 'lib');
   const projectPath = await elixirProjectPath(textEditor);
   try {
@@ -271,7 +271,8 @@ const lintElixirc = async (textEditor) => {
     '-o',
     tempDir.name,
   ];
-  await getDepsPa(textEditor).forEach((item) => {
+  const paDeps = await getDepsPa(textEditor);
+  paDeps.forEach((item) => {
     elixircArgs.push('-pa', item);
   });
   elixircArgs.push(textEditor.getPath());
@@ -331,7 +332,7 @@ export default {
           isForcedElixirc() ||
             !(await isMixProject(textEditor)) ||
             isExsFile(textEditor) ||
-            await isPhoenixProject(textEditor)
+            (await isPhoenixProject(textEditor))
         ) {
           return lintElixirc(textEditor);
         }

--- a/lib/init.js
+++ b/lib/init.js
@@ -5,7 +5,8 @@ import { CompositeDisposable, Range } from 'atom';
 import { findAsync, rangeFromLineNumber, exec } from 'atom-linter';
 import { dirname, join, relative, sep } from 'path';
 import { existsSync, readFileSync, readdirSync } from 'fs';
-import { tmpDir } from 'os';
+
+const tmp = require('tmp');
 
 // Internal values
 const elixirProjectPathCache = new Map();
@@ -259,6 +260,7 @@ const getDepsPa = async (textEditor) => {
 };
 
 const lintElixirc = async (textEditor) => {
+  const tempDir = tmp.dirSync({ unsafeCleanup: true });
   const elixircArgs = [
     '--ignore-module-conflict',
     '--app',
@@ -266,15 +268,22 @@ const lintElixirc = async (textEditor) => {
     '--app',
     'ex_unit',
     '-o',
-    tmpDir(),
+    tempDir.name,
   ];
   await getDepsPa(textEditor).forEach((item) => {
     elixircArgs.push('-pa', item);
   });
   elixircArgs.push(textEditor.getPath());
 
+  const fileText = textEditor.getText();
   const execOpts = await getOpts(textEditor);
   const result = await exec(elixircPath, elixircArgs, execOpts);
+  // Cleanup the temp dir
+  tempDir.removeCallback();
+  if (textEditor.getText !== fileText) {
+    // File contents have changed since the run was triggered, don't update messages
+    return null;
+  }
   return handleResult(textEditor, result);
 };
 

--- a/lib/init.js
+++ b/lib/init.js
@@ -282,7 +282,7 @@ const lintElixirc = async (textEditor) => {
   const result = await exec(elixircPath, elixircArgs, execOpts);
   // Cleanup the temp dir
   tempDir.removeCallback();
-  if (textEditor.getText !== fileText) {
+  if (textEditor.getText() !== fileText) {
     // File contents have changed since the run was triggered, don't update messages
     return null;
   }

--- a/lib/init.js
+++ b/lib/init.js
@@ -92,16 +92,16 @@ const parseError = async (toParse, textEditor) => {
   const re = regexp(
     `
     \\*\\*[\\ ]+
-    \\((\\w+)\\)                   ${''}
-    [\\ ](?:                       ${''}
-      ([\\w\\ ]+)                  ${''}
-      [\\r\\n]{1,2}.+[\\r\\n]{1,2} ${''}
-      [\\ ]+(.+)                   ${''}
-      :(\\d+):                     ${''}
-    |                              ${''}
-      (.+)                         ${''}
-      :(\\d+):                     ${''}
-      [\\ ](.+)                    ${''}
+    \\((\\w+)\\)                   ${''/* 1 - (TypeOfError)*/}
+    [\\ ](?:                       ${''/* Two message formats.... mode one*/}
+      ([\\w\\ ]+)                  ${''/* 2 - Message*/}
+      [\\r\\n]{1,2}.+[\\r\\n]{1,2} ${''/* Internal elixir code*/}
+      [\\ ]+(.+)                   ${''/* 3 - File*/}
+      :(\\d+):                     ${''/* 4 - Line*/}
+    |                              ${''/* Or... mode two*/}
+      (.+)                         ${''/* 5 - File*/}
+      :(\\d+):                     ${''/* 6 - Line*/}
+      [\\ ](.+)                    ${''/* 7 - Message*/}
     )
   `,
     'gm',
@@ -150,8 +150,8 @@ const parseWarning = async (toParse, textEditor) => {
   const messages = [];
   const re = regexp(
     `
-    warning:\\ (.*)\\n ${''}
-    \\ \\ (.*):([0-9]+) ${''}
+    warning:\\ (.*)\\n  ${''/* warning */}
+    \\ \\ (.*):([0-9]+) ${''/* file and file number */}
     `,
     'g',
   );
@@ -188,10 +188,10 @@ const parseLegacyWarning = async (toParse, textEditor) => {
   const messages = [];
   const re = regexp(
     `
-    ([^:\\n]*)   ${''}
-    :(\\d+)      ${''}
+    ([^:\\n]*)   ${''/* 1 - File name */}
+    :(\\d+)      ${''/* 2 - Line */}
     :\\ warning
-    :\\ (.*)     ${''}
+    :\\ (.*)     ${''/* 3 - Message */}
     `,
     'g',
   );

--- a/lib/init.js
+++ b/lib/init.js
@@ -219,7 +219,7 @@ export default {
         const warningStack = parseWarning(resultString, textEditor);
         const legacyWarningStack = parseLegacyWarning(resultString, textEditor);
         return Array
-          .from(errorStack.concat(warningStack))
+          .from(errorStack.concat(warningStack).concat(legacyWarningStack))
           .filter(error => error != null)
           .map(error => error);
       } catch (Error) {

--- a/lib/init.js
+++ b/lib/init.js
@@ -2,13 +2,13 @@
 
 // eslint-disable-next-line import/no-extraneous-dependencies, import/extensions
 import { CompositeDisposable, Range } from 'atom';
-import { findCachedAsync, rangeFromLineNumber, exec } from 'atom-linter';
+import { findAsync, rangeFromLineNumber, exec } from 'atom-linter';
 import { dirname, join, relative, sep } from 'path';
 import { existsSync, readFileSync, readdirSync } from 'fs';
 import { tmpDir } from 'os';
 
 // Internal values
-const elixirProjectPathCache = {};
+const elixirProjectPathCache = new Map();
 let elixircPath;
 let mixPath;
 let forceElixirc;
@@ -23,11 +23,11 @@ function regexp(string, flags) {
   );
 }
 
-// find elixir project in the file path by locating mix.exs, otherwise
-// fallback to project path or file path
+// Find elixir project in the file path by locating mix.exs, otherwise
+//  fallback to project path or file path
 const findElixirProjectPath = async (editorPath) => {
   const editorDir = dirname(editorPath);
-  const mixexsPath = await findCachedAsync(editorDir, 'mix.exs');
+  const mixexsPath = await findAsync(editorDir, 'mix.exs');
   if (mixexsPath !== null) {
     return mixexsPath;
   }
@@ -38,12 +38,14 @@ const findElixirProjectPath = async (editorPath) => {
   return editorDir;
 };
 
-// memoize the project path per file (traversing is quite expensive)
+// Memoize the project path per file (traversing is quite expensive)
 const elixirProjectPath = async (textEditor) => {
   const editorPath = textEditor.getPath();
-  if (elixirProjectPathCache[editorPath]) { return elixirProjectPathCache[editorPath]; }
+  if (elixirProjectPathCache.has(editorPath)) {
+    return elixirProjectPathCache.get(editorPath);
+  }
   const projectPath = await findElixirProjectPath(editorPath);
-  elixirProjectPathCache[editorPath] = projectPath;
+  elixirProjectPathCache.set(editorPath, projectPath);
   return projectPath;
 };
 

--- a/lib/init.js
+++ b/lib/init.js
@@ -204,14 +204,13 @@ const handleResult = async (compileResult, textEditor) => {
     const errorStack = await parseError(resultString, textEditor);
     const warningStack = await parseWarning(resultString, textEditor);
     const legacyWarningStack = await parseLegacyWarning(resultString, textEditor);
-    return Array
-      .from(errorStack.concat(warningStack).concat(legacyWarningStack))
-      .filter(error => error != null)
+    return errorStack.concat(warningStack).concat(legacyWarningStack)
+      .filter(error => error !== null)
       .map(error => error);
   } catch (Error) {
     // eslint-disable-next-line no-console
     console.error('linter-elixirc:', Error);
-    return []; // error in different file, just suppress
+    return []; // Error is in a different file, just suppress
   }
 };
 
@@ -247,7 +246,7 @@ const lintElixirc = async (textEditor) => {
     '-o',
     tmpDir(),
   ];
-  Array.from(await getDepsPa(textEditor)).forEach((item) => {
+  await getDepsPa(textEditor).forEach((item) => {
     elixircArgs.push('-pa', item);
   });
   elixircArgs.push(textEditor.getPath());

--- a/lib/init.js
+++ b/lib/init.js
@@ -75,6 +75,16 @@ const isPhoenixProject = async (textEditor) => {
   }
 };
 
+const findTextEditor = (filePath) => {
+  const allEditors = atom.workspace.getTextEditors();
+  const matchingEditor = allEditors.find(
+    textEditor => textEditor.getPath() === filePath);
+  if (matchingEditor !== undefined) {
+    return matchingEditor;
+  }
+  return false;
+};
+
 const parseError = async (toParse, textEditor) => {
   const messages = [];
   const re = regexp(
@@ -103,11 +113,13 @@ const parseError = async (toParse, textEditor) => {
     if (reResult[2] !== null) {
       text = `(${reResult[1]}) ${reResult[2]}`;
       filePath = join(projectPath, reResult[3]);
-      if (filePath === textEditor.getPath()) {
-        // If the Error is in the current file, we can get a better range
-        // using rangeFromLineNumber, otherwise generate a 1 character range
-        // that can be updated to a proper range if/when the file is opened.
-        range = rangeFromLineNumber(textEditor, reResult[4] - 1);
+      const fileEditor = findTextEditor(filePath);
+      if (fileEditor) {
+        // If there is an open TextEditor instance for the file from the Error,
+        // we can get a better range using rangeFromLineNumber, otherwise
+        // generate a 1 character range that can be updated to a proper range
+        // if/when the file is opened.
+        range = rangeFromLineNumber(fileEditor, reResult[4] - 1);
       } else {
         range = new Range([reResult[4] - 1, 0], [reResult[4] - 1, 1]);
       }
@@ -148,8 +160,9 @@ const parseWarning = async (toParse, textEditor) => {
     const filePath = join(projectPath, reResult[2]);
     try {
       let range;
-      if (filePath === textEditor.getPath()) {
-        range = rangeFromLineNumber(textEditor, reResult[3] - 1);
+      const fileEditor = findTextEditor(filePath);
+      if (fileEditor) {
+        range = rangeFromLineNumber(fileEditor, reResult[3] - 1);
       } else {
         range = new Range([reResult[3] - 1, 0], [reResult[3] - 1, 1]);
       }
@@ -186,8 +199,9 @@ const parseLegacyWarning = async (toParse, textEditor) => {
     const filePath = join(projectPath, reResult[1]);
     try {
       let range;
-      if (filePath === textEditor.getPath()) {
-        range = rangeFromLineNumber(textEditor, reResult[3] - 1);
+      const fileEditor = findTextEditor(filePath);
+      if (fileEditor) {
+        range = rangeFromLineNumber(fileEditor, reResult[3] - 1);
       } else {
         range = new Range([reResult[3] - 1, 0], [reResult[3] - 1, 1]);
       }

--- a/lib/init.js
+++ b/lib/init.js
@@ -2,7 +2,7 @@
 
 // eslint-disable-next-line import/no-extraneous-dependencies, import/extensions
 import { CompositeDisposable, Range } from 'atom';
-import { findAsync, rangeFromLineNumber, exec } from 'atom-linter';
+import { find, rangeFromLineNumber, exec } from 'atom-linter';
 import { dirname, join, relative, sep } from 'path';
 import { existsSync, readFileSync, readdirSync } from 'fs';
 
@@ -28,9 +28,9 @@ function regexp(string, flags) {
 //  fallback to project path or file path
 const findElixirProjectPath = async (editorPath) => {
   const editorDir = dirname(editorPath);
-  const mixexsPath = await findAsync(editorDir, 'mix.exs');
+  const mixexsPath = find(editorDir, 'mix.exs');
   if (mixexsPath !== null) {
-    return mixexsPath;
+    return dirname(mixexsPath);
   }
   const projPath = atom.project.relativizePath(editorPath)[0];
   if (projPath !== null) {

--- a/lib/init.js
+++ b/lib/init.js
@@ -58,6 +58,7 @@ const isMixProject = async (textEditor) => {
 const isTestFile = async (textEditor) => {
   const project = await elixirProjectPath(textEditor);
   const relativePath = relative(project, textEditor.getPath());
+  // Is the first directory of the relative path "test"?
   return relativePath.split(sep)[0] === 'test';
 };
 
@@ -296,6 +297,7 @@ const lintMix = async (textEditor) => {
 export default {
   activate() {
     require('atom-package-deps').install('linter-elixirc');
+
     this.subscriptions = new CompositeDisposable();
     this.subscriptions.add(
       atom.config.observe('linter-elixirc.elixircPath', (value) => {
@@ -307,7 +309,7 @@ export default {
         mixPath = value;
       }),
     );
-    return this.subscriptions.add(
+    this.subscriptions.add(
       atom.config.observe('linter-elixirc.forceElixirc', (value) => {
         forceElixirc = value;
       }),

--- a/lib/init.js
+++ b/lib/init.js
@@ -184,7 +184,7 @@ const parseLegacyWarning = async (toParse, textEditor) => {
   return ret;
 };
 
-const handleResult = async textEditor => async (compileResult) => {
+const handleResult = async (compileResult, textEditor) => {
   const resultString = `${compileResult.stdout}\n${compileResult.stderr}`;
   try {
     const errorStack = await parseError(resultString, textEditor);
@@ -239,13 +239,16 @@ const lintElixirc = async (textEditor) => {
   });
   elixircArgs.push(textEditor.getPath());
 
-  return exec(elixircPath, elixircArgs, await getOpts(textEditor))
-    .then(handleResult(textEditor));
+  const execOpts = await getOpts(textEditor);
+  const result = await exec(elixircPath, elixircArgs, execOpts);
+  return handleResult(textEditor, result);
 };
 
-const lintMix = async textEditor =>
-  exec(mixPath, ['compile'], await getOpts(textEditor))
-    .then(handleResult(textEditor));
+const lintMix = async (textEditor) => {
+  const execOpts = await getOpts(textEditor);
+  const result = await exec(mixPath, ['compile'], execOpts);
+  return handleResult(textEditor, result);
+};
 
 export default {
   activate() {

--- a/lib/init.js
+++ b/lib/init.js
@@ -286,13 +286,13 @@ const lintElixirc = async (textEditor) => {
     // File contents have changed since the run was triggered, don't update messages
     return null;
   }
-  return handleResult(textEditor, result);
+  return handleResult(result, textEditor);
 };
 
 const lintMix = async (textEditor) => {
   const execOpts = await getOpts(textEditor);
   const result = await exec(mixPath, ['compile'], execOpts);
-  return handleResult(textEditor, result);
+  return handleResult(result, textEditor);
 };
 
 export default {

--- a/package.json
+++ b/package.json
@@ -23,5 +23,31 @@
   "dependencies": {
     "atom-linter": "^8.0.0",
     "atom-package-deps": "^4.0.1"
+  },
+  "devDependencies": {
+    "eslint": "^3.13.0",
+    "eslint-config-airbnb-base": "^11.0.1",
+    "eslint-plugin-import": "^2.2.0"
+  },
+  "eslintConfig": {
+    "extends": "airbnb-base",
+    "rules": {
+      "global-require": "off",
+      "import/no-unresolved": [
+        "error",
+        {
+          "ignore": [
+            "atom"
+          ]
+        }
+      ]
+    },
+    "globals": {
+      "atom": true
+    },
+    "env": {
+      "node": true,
+      "browser": true
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
   ],
   "dependencies": {
     "atom-linter": "^8.0.0",
-    "atom-package-deps": "^4.0.1"
+    "atom-package-deps": "^4.0.1",
+    "tmp": "^0.0.31"
   },
   "devDependencies": {
     "eslint": "^3.13.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,25 @@
   "repository": "https://github.com/AtomLinter/linter-elixirc",
   "license": "MIT",
   "engines": {
-    "atom": ">0.50.0"
+    "atom": ">=1.4.0 <2.0.0"
+  },
+  "configSchema": {
+    "elixircPath": {
+      "type": "string",
+      "title": "Elixirc path",
+      "default": "elixirc"
+    },
+    "mixPath": {
+      "type": "string",
+      "title": "Mix path",
+      "default": "mix"
+    },
+    "forceElixirc": {
+      "type": "boolean",
+      "title": "Always use elixirc",
+      "description": "Activating this will force the plugin to never use `mix compile` and always use `elixirc`.",
+      "default": false
+    }
   },
   "providedServices": {
     "linter": {

--- a/spec/.eslintrc.js
+++ b/spec/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  env: {
+    jasmine: true,
+    atomtest: true
+  }
+};

--- a/spec/fixtures/error-mode1.ex
+++ b/spec/fixtures/error-mode1.ex
@@ -1,0 +1,7 @@
+# Multi-line error, mode 1
+defimpl Dangerous, for: Ninja do
+  def attack(weapon = %Weapon{}, defender = %Ninja{}) do
+    # There is a bug here (attack/0 doesn't exist), this will make warrior.ex crash
+    [attack, defender]
+  end
+end

--- a/spec/fixtures/error-mode2.ex
+++ b/spec/fixtures/error-mode2.ex
@@ -1,0 +1,22 @@
+# Multi-line error, mode 2
+defmodule UsefulnessTest do
+  use ExUnit.Case
+  doctest Usefulness
+  doctest Usefulness.Stream
+  doctest Usefulness.String
+end
+
+# Single line error, still mode 2
+defmodule Identicon do
+  def main(input) do
+    input
+    |> hash_input
+  end
+
+  def has_input(input) do
+    hex = :crypto.has(:md5, input)
+    |> :binary.bin_to_list
+
+    %Identicon.Image{hex: hex}
+  end
+end

--- a/spec/fixtures/proj/lib/proj.ex
+++ b/spec/fixtures/proj/lib/proj.ex
@@ -1,0 +1,28 @@
+defmodule Proj do
+  use GenServer
+
+  def start do
+    GenServer.start(__MODULE__, nil, name: :kv_server)
+  end
+
+  def put(key, val) do
+    GenServer.cast(:kv_server, {:put, key, val})
+  end
+
+  def get(key) do
+    GenServer.call(:kv_server, {:get, key})
+  end
+
+  def init(_) do
+    {:ok, %{}}
+  end
+
+  def handle_call({:get, key}, _caller, state) do
+    {:reply, Map.get(state, key), state}
+  end
+
+  def handle_cast({:put, key, val}, state) do
+    {:noreply, Map.put(state, key, val), state}
+  end
+
+end

--- a/spec/fixtures/proj/mix.exs
+++ b/spec/fixtures/proj/mix.exs
@@ -1,0 +1,32 @@
+defmodule Proj.Mixfile do
+  use Mix.Project
+
+  def project do
+    [app: :proj,
+     version: "0.0.1",
+     elixir: "~> 1.4",
+     build_embedded: Mix.env == :prod,
+     start_permanent: Mix.env == :prod,
+     deps: deps]
+  end
+
+  # Configuration for the OTP application
+  #
+  # Type "mix help compile.app" for more information
+  def application do
+    [applications: [:logger]]
+  end
+
+  # Dependencies can be Hex packages:
+  #
+  #   {:mydep, "~> 0.3.0"}
+  #
+  # Or git/path repositories:
+  #
+  #   {:mydep, git: "https://github.com/elixir-lang/mydep.git", tag: "0.1.0"}
+  #
+  # Type "mix help deps" for more examples and options
+  defp deps do
+    []
+  end
+end

--- a/spec/fixtures/valid.ex
+++ b/spec/fixtures/valid.ex
@@ -1,0 +1,3 @@
+def start do
+  42
+end

--- a/spec/linter-elixirc-spec.js
+++ b/spec/linter-elixirc-spec.js
@@ -1,0 +1,70 @@
+'use babel';
+
+import { join } from 'path';
+
+const validPath = join(__dirname, 'fixtures', 'valid.ex');
+const warningPath = join(__dirname, 'fixtures', 'proj', 'mix.exs');
+const errorMode1Path = join(__dirname, 'fixtures', 'error-mode1.ex');
+const errorMode2Path = join(__dirname, 'fixtures', 'error-mode2.ex');
+
+describe('The elixirc provider for Linter', () => {
+  const lint = require('../lib/init.js').provideLinter().lint;
+
+  beforeEach(() => {
+    atom.workspace.destroyActivePaneItem();
+
+    waitsForPromise(() =>
+      Promise.all([
+        atom.packages.activatePackage('linter-elixirc'),
+        atom.packages.activatePackage('language-elixir'),
+      ]),
+    );
+  });
+
+  it('works with mode 1 errors', () => {
+    waitsForPromise(() =>
+      atom.workspace.open(errorMode1Path).then(editor => lint(editor)).then((messages) => {
+        expect(messages.length).toBe(1);
+        expect(messages[0].type).toBe('Error');
+        expect(messages[0].html).not.toBeDefined();
+        expect(messages[0].text).toBe('(ArgumentError) Dangerous is not available');
+        expect(messages[0].filePath).toBe(errorMode1Path);
+        expect(messages[0].range).toEqual([[1, 0], [1, 32]]);
+      }),
+    );
+  });
+
+  it('works with mode 2 errors', () => {
+    waitsForPromise(() =>
+      atom.workspace.open(errorMode2Path).then(editor => lint(editor)).then((messages) => {
+        expect(messages.length).toBe(1);
+        expect(messages[0].type).toBe('Error');
+        expect(messages[0].html).not.toBeDefined();
+        expect(messages[0].text).toBe('(CompileError) module Usefulness is not loaded and could not be found');
+        expect(messages[0].filePath).toBe(errorMode2Path);
+        expect(messages[0].range).toEqual([[3, 2], [3, 20]]);
+      }),
+    );
+  });
+
+  it('works with warnings', () => {
+    waitsForPromise(() =>
+      atom.workspace.open(warningPath).then(editor => lint(editor)).then((messages) => {
+        expect(messages.length).toBe(1);
+        expect(messages[0].type).toBe('Warning');
+        expect(messages[0].html).not.toBeDefined();
+        expect(messages[0].text).toBe('variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name');
+        expect(messages[0].filePath).toBe(warningPath);
+        expect(messages[0].range).toEqual([[9, 5], [9, 16]]);
+      }),
+    );
+  });
+
+  it('finds nothing wrong with a valid file', () => {
+    waitsForPromise(() =>
+      atom.workspace.open(validPath).then(editor => lint(editor)).then((messages) => {
+        expect(messages.length).toBe(0);
+      }),
+    );
+  });
+});


### PR DESCRIPTION
Includes many changes, not limited to:

* Adding ESLint to the project so a consistent code style can be enforced
* Legacy warnings, although parsed, were not being included in the results
* Move configuration definition to the `package.json` so Atom doesn't have to run the code to determine the settings
*  Where possible, use `rangeFromLineNumber` to return a better range
* Properly handle files other than the currently active one
* Clean up the temporary directory used for compile output
* Handle a race condition where the file is edited between when a lint was requested and the results return
* Add specs!