### PR TITLE
Include mixEnv parameter and apply to environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Plugin should work with default settings. If not:
 
 5.  `always use elixirc` option - leave it disabled, unless `mix compile` is too slow.
 
+6.  `mix env` option - Allows changing the Mix environment for lint runs. If using IEx at the same time as Atom this can be changed to allow IEx to pick up code changes.
+
 ## Usage
 
 If you open folder with mix project (`mix.exs` exists in project's root

--- a/lib/init.js
+++ b/lib/init.js
@@ -13,6 +13,7 @@ const elixirProjectPathCache = new Map();
 let elixircPath;
 let mixPath;
 let forceElixirc;
+let mixEnv;
 
 function regexp(string, flags) {
   return new RegExp(
@@ -243,6 +244,7 @@ const getOpts = async filePath => ({
   throwOnStdErr: false,
   stream: 'both',
   allowEmptyStderr: true,
+  env: { MIX_ENV: mixEnv },
 });
 
 const getDepsPa = async (filePath) => {
@@ -320,6 +322,11 @@ export default {
     this.subscriptions.add(
       atom.config.observe('linter-elixirc.forceElixirc', (value) => {
         forceElixirc = value;
+      }),
+    );
+    this.subscriptions.add(
+      atom.config.observe('linter-elixirc.mixEnv', (value) => {
+        mixEnv = value;
       }),
     );
   },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,12 @@
       "title": "Always use elixirc",
       "description": "Activating this will force the plugin to never use `mix compile` and always use `elixirc`.",
       "default": false
+    },
+    "mixEnv": {
+      "type": "string",
+      "title": "Mix environment to use for linting",
+      "description": "Setting the Mix environment can avoid collisions between linter compiles and IEx sessions.",
+      "default": "dev"
     }
   },
   "providedServices": {


### PR DESCRIPTION
In a comment on closed issue #80, I made a suggestion that a workaround could be to apply the `mix compile` command to a different Mix environment so that a separation between the linter and IEx can be maintained.

For example, in normal usage, launching IEx will often be run in the `dev` environment. As a result, the build output will go to `_build/dev/`. When the linter runs, it outputs to the same location, causing confusion for IEx when it is ordered to recompile.

This change allows the user to specify a Mix environment that the linter should use. This allows linting for the `test` or `prod` environments if that is preferred, or allows a separation between IEx output and linter output.

Note: I had trouble getting linter-elixirc to load in `--dev` mode (complained about not being able to find the module atom-elixir). I did test this by applying changes directly to my regular package directory, but I'll keep trying to test it directly from dev mode. I just wanted to get this PR up for discussion.