### PR TITLE
Update to use Linter v2 provider and message formats

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -109,11 +109,11 @@ const parseError = async (toParse, sourceFilePath) => {
   const projectPath = await elixirProjectPath(sourceFilePath);
   let reResult = re.exec(toParse);
   while (reResult !== null) {
-    let text;
+    let excerpt;
     let filePath;
     let range;
     if (reResult[2] !== undefined) {
-      text = `(${reResult[1]}) ${reResult[2]}`;
+      excerpt = `(${reResult[1]}) ${reResult[2]}`;
       filePath = join(projectPath, reResult[3]);
       const fileEditor = findTextEditor(filePath);
       if (fileEditor) {
@@ -126,7 +126,7 @@ const parseError = async (toParse, sourceFilePath) => {
         range = new Range([reResult[4] - 1, 0], [reResult[4] - 1, 1]);
       }
     } else {
-      text = `(${reResult[1]}) ${reResult[7]}`;
+      excerpt = `(${reResult[1]}) ${reResult[7]}`;
       filePath = join(projectPath, reResult[5]);
       const fileEditor = findTextEditor(filePath);
       if (fileEditor) {
@@ -136,10 +136,9 @@ const parseError = async (toParse, sourceFilePath) => {
       }
     }
     messages.push({
-      type: 'Error',
-      text,
-      filePath,
-      range,
+      severity: 'error',
+      excerpt: excerpt,
+      location: { file: filePath, position: range },
     });
     reResult = re.exec(toParse);
   }
@@ -170,10 +169,9 @@ const parseWarning = async (toParse, sourceFilePath) => {
         range = new Range([reResult[3] - 1, 0], [reResult[3] - 1, 1]);
       }
       messages.push({
-        type: 'Warning',
-        text: reResult[1],
-        filePath,
-        range,
+        severity: 'warning',
+        excerpt: reResult[1],
+        location: { file: filePath, position: range },
       });
     } catch (Error) {
       // eslint-disable-next-line no-console
@@ -209,10 +207,9 @@ const parseLegacyWarning = async (toParse, sourceFilePath) => {
         range = new Range([reResult[3] - 1, 0], [reResult[3] - 1, 1]);
       }
       messages.push({
-        type: 'Warning',
-        text: reResult[3],
-        filePath,
-        range,
+        severity: 'warning',
+        excerpt: reResult[3],
+        location: { file: filePath, position: range },
       });
     } catch (Error) {
       // eslint-disable-next-line no-console
@@ -339,7 +336,7 @@ export default {
     return {
       grammarScopes: ['source.elixir'],
       scope: 'project',
-      lintOnFly: false,
+      lintsOnChange: false,
       name: 'Elixir',
       async lint(textEditor) {
         const filePath = textEditor.getPath();

--- a/lib/init.js
+++ b/lib/init.js
@@ -137,7 +137,7 @@ const parseError = async (toParse, sourceFilePath) => {
     }
     messages.push({
       severity: 'error',
-      excerpt: excerpt,
+      excerpt,
       location: { file: filePath, position: range },
     });
     reResult = re.exec(toParse);

--- a/package.json
+++ b/package.json
@@ -41,12 +41,12 @@
     }
   },
   "package-deps": [
-    "linter",
+    "linter:2.0.0",
     "language-elixir"
   ],
   "dependencies": {
     "atom-linter": "^9.0.0",
-    "atom-package-deps": "^4.0.1",
+    "atom-package-deps": "^4.5.0",
     "tmp": "^0.0.31"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "providedServices": {
     "linter": {
       "versions": {
-        "1.0.0": "provideLinter"
+        "2.0.0": "provideLinter"
       }
     }
   },

--- a/spec/linter-elixirc-spec.js
+++ b/spec/linter-elixirc-spec.js
@@ -25,11 +25,11 @@ describe('The elixirc provider for Linter', () => {
     waitsForPromise(() =>
       atom.workspace.open(errorMode1Path).then(editor => lint(editor)).then((messages) => {
         expect(messages.length).toBe(1);
-        expect(messages[0].type).toBe('Error');
+        expect(messages[0].severity).toBe('error');
         expect(messages[0].html).not.toBeDefined();
-        expect(messages[0].text).toBe('(ArgumentError) Dangerous is not available');
-        expect(messages[0].filePath).toBe(errorMode1Path);
-        expect(messages[0].range).toEqual([[1, 0], [1, 32]]);
+        expect(messages[0].excerpt).toBe('(ArgumentError) Dangerous is not available');
+        expect(messages[0].location.file).toBe(errorMode1Path);
+        expect(messages[0].location.position).toEqual([[1, 0], [1, 32]]);
       }),
     );
   });
@@ -38,11 +38,11 @@ describe('The elixirc provider for Linter', () => {
     waitsForPromise(() =>
       atom.workspace.open(errorMode2Path).then(editor => lint(editor)).then((messages) => {
         expect(messages.length).toBe(1);
-        expect(messages[0].type).toBe('Error');
+        expect(messages[0].severity).toBe('error');
         expect(messages[0].html).not.toBeDefined();
-        expect(messages[0].text).toBe('(CompileError) module Usefulness is not loaded and could not be found');
-        expect(messages[0].filePath).toBe(errorMode2Path);
-        expect(messages[0].range).toEqual([[3, 2], [3, 20]]);
+        expect(messages[0].excerpt).toBe('(CompileError) module Usefulness is not loaded and could not be found');
+        expect(messages[0].location.file).toBe(errorMode2Path);
+        expect(messages[0].location.position).toEqual([[3, 2], [3, 20]]);
       }),
     );
   });
@@ -51,11 +51,11 @@ describe('The elixirc provider for Linter', () => {
     waitsForPromise(() =>
       atom.workspace.open(warningPath).then(editor => lint(editor)).then((messages) => {
         expect(messages.length).toBe(1);
-        expect(messages[0].type).toBe('Warning');
+        expect(messages[0].severity).toBe('warning');
         expect(messages[0].html).not.toBeDefined();
-        expect(messages[0].text).toBe('variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name');
-        expect(messages[0].filePath).toBe(warningPath);
-        expect(messages[0].range).toEqual([[9, 5], [9, 16]]);
+        expect(messages[0].excerpt).toBe('variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name');
+        expect(messages[0].location.file).toBe(warningPath);
+        expect(messages[0].location.position).toEqual([[9, 5], [9, 16]]);
       }),
     );
   });


### PR DESCRIPTION
Following the recent release of the Linter v2 APIs, I've made an attempt to update this package to use the new APIs.

This includes to main changes:

* adopt the [Standard Linter v2 API](https://github.com/steelbrain/linter/blob/master/docs/types/standard-linter-v2.md) - this entailed updating the `package.json`
* adopt the [Linter Message v2 API](https://github.com/steelbrain/linter/blob/master/docs/types/linter-message-v2.md) - this required changes to the messages constructed for sending to the linter, specifically `type` became `severity`, `text` became `excerpt`, and `file` and `range` were combined into a `location` structure.

I've updated the specs to reflect the changes, but I should note that the specs failed on my Mac without any of my changes applied. The failures are the same before and after my changes, so I'm not sure if this is an environment issue.

Are there other considerations that are needed at this time (for example, versioning to reflect the adoption of the new API)?

P.S. Apologies if I'm jumping the gun by making this update -- I checked for outstanding issues referencing it, but saw none. Not trying to tread on anyone's toes though.