### PR TITLE
Account for umbrella projects when determining project path

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -71,18 +71,17 @@ const isMixProject = async (filePath) => {
 const isUmbrellaProject = async (filePath) => {
   const project = await elixirProjectPath(filePath);
   return existsSync(join(project, 'apps'));
-}
+};
 
 const isTestFile = async (filePath) => {
   const project = await elixirProjectPath(filePath);
   const relativePath = relative(project, filePath);
-  if (isUmbrellaProject()) {
+  if (isUmbrellaProject(filePath)) {
     // Is the structure "apps/app_name/test/..."
     return relativePath.split(sep)[2] === 'test';
-  } else {
-    // Is the structure "test/..."
-    return relativePath.split(sep)[0] === 'test';
   }
+  // Is the structure "test/..."
+  return relativePath.split(sep)[0] === 'test';
 };
 
 const isForcedElixirc = () => forceElixirc;

--- a/lib/init.js
+++ b/lib/init.js
@@ -31,12 +31,12 @@ const findElixirProjectPath = async (editorPath) => {
   const editorDir = dirname(editorPath);
   const mixexsPath = find(editorDir, 'mix.exs');
   if (mixexsPath !== null) {
-    const pathArray = mixexsPath.split('/');
+    const pathArray = mixexsPath.split(sep);
     if (pathArray.length > 3 && pathArray[pathArray.length - 3] === 'apps') {
       //  Treat this as an umbrella app. This may be wrong -
       //  If you happen to keep your code in a directory called 'apps'
       pathArray.splice((pathArray.length - 3), 3);
-      const umbrellaProjectPath = pathArray.join('/');
+      const umbrellaProjectPath = pathArray.join(sep);
 
       //  Safety check by looking for a `mix.exs` file in the same directory as
       //  'apps'. If it exists, then it's likely an umbrella project
@@ -68,11 +68,21 @@ const isMixProject = async (filePath) => {
   return existsSync(join(project, 'mix.exs'));
 };
 
+const isUmbrellaProject = async (filePath) => {
+  const project = await elixirProjectPath(filePath);
+  return existsSync(join(project, 'apps'));
+}
+
 const isTestFile = async (filePath) => {
   const project = await elixirProjectPath(filePath);
   const relativePath = relative(project, filePath);
-  // Is the first directory of the relative path "test"?
-  return relativePath.split(sep)[0] === 'test';
+  if (isUmbrellaProject()) {
+    // Is the structure "apps/app_name/test/..."
+    return relativePath.split(sep)[2] === 'test';
+  } else {
+    // Is the structure "test/..."
+    return relativePath.split(sep)[0] === 'test';
+  }
 };
 
 const isForcedElixirc = () => forceElixirc;

--- a/lib/init.js
+++ b/lib/init.js
@@ -31,6 +31,19 @@ const findElixirProjectPath = async (editorPath) => {
   const editorDir = dirname(editorPath);
   const mixexsPath = find(editorDir, 'mix.exs');
   if (mixexsPath !== null) {
+    const pathArray = mixexsPath.split('/');
+    if (pathArray.length > 3 && pathArray[pathArray.length - 3] === 'apps') {
+      //  Treat this as an umbrella app. This may be wrong -
+      //  If you happen to keep your code in a directory called 'apps'
+      pathArray.splice((pathArray.length - 3), 3);
+      const umbrellaProjectPath = pathArray.join('/');
+
+      //  Safety check by looking for a `mix.exs` file in the same directory as
+      //  'apps'. If it exists, then it's likely an umbrella project
+      if (existsSync(join(umbrellaProjectPath, 'mix.exs'))) {
+        return umbrellaProjectPath;
+      }
+    }
     return dirname(mixexsPath);
   }
   const projPath = atom.project.relativizePath(editorPath)[0];


### PR DESCRIPTION
I'd previously noticed that I was having some problems with linting in umbrella projects. With some debugging, I noticed that the Elixir project path was being determined by the location of the `mix.exs` file. Unfortunately there are multiple Mix files in an umbrella project, so we need to take the top-level one to determine the project directory.

Umbrella projects are characterised by the following structure

```
project_dir/
 |
 +-- mix.exs
 +-- apps/
      |
       +-- app_name/
            |
            +- mix.exs
```

The existing `findElixirProjectPath()` function will find the lowest level `mix.exs` file. I have modified this function to check for `apps` in the project structure two levels up. If that exists AND there is another `mix.exs` file up there, then the function will assume an umbrella project, and return that directory. Otherwise it falls back to the regular pattern.