### PR TITLE
Await the result of isUmbrellaProject()

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -74,9 +74,11 @@ const isUmbrellaProject = async (filePath) => {
 };
 
 const isTestFile = async (filePath) => {
+  const umbrellaProject = await isUmbrellaProject(filePath);
   const project = await elixirProjectPath(filePath);
   const relativePath = relative(project, filePath);
-  if (isUmbrellaProject(filePath)) {
+
+  if (umbrellaProject) {
     // Is the structure "apps/app_name/test/..."
     return relativePath.split(sep)[2] === 'test';
   }


### PR DESCRIPTION
When the check for umbrella projects (`isUmbrellaProject()`) was introduced, the test file detection function was updated to [use the check](https://github.com/AtomLinter/linter-elixirc/blob/master/lib/init.js#L79).

Unfortunately it was not called with an `await` instruction so the calling code was moving on without waiting for the result, and was following the code path for umbrella projects.

This PR adds in the missing `await`. I believe it addresses the bug reported in #90.