### PR TITLE
Fix absolute vs relative path issues

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -3,7 +3,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies, import/extensions
 import { CompositeDisposable, Range } from 'atom';
 import { find, generateRange, exec } from 'atom-linter';
-import { dirname, join, relative, sep } from 'path';
+import { dirname, join, relative, sep, isAbsolute } from 'path';
 import { existsSync, readFileSync, readdirSync } from 'fs';
 
 const tmp = require('tmp');
@@ -109,6 +109,13 @@ const findTextEditor = (filePath) => {
   return false;
 };
 
+const ensureAbsolutePath = (projectPath, filePath) => {
+  if (isAbsolute(filePath)) {
+    return filePath;
+  }
+  return join(projectPath, filePath);
+};
+
 const parseError = async (toParse, sourceFilePath) => {
   const messages = [];
   const re = regexp(
@@ -136,7 +143,7 @@ const parseError = async (toParse, sourceFilePath) => {
     let range;
     if (reResult[2] !== undefined) {
       excerpt = `(${reResult[1]}) ${reResult[2]}`;
-      filePath = join(projectPath, reResult[3]);
+      filePath = ensureAbsolutePath(projectPath, reResult[3]);
       const fileEditor = findTextEditor(filePath);
       if (fileEditor) {
         // If there is an open TextEditor instance for the file from the Error,
@@ -149,7 +156,7 @@ const parseError = async (toParse, sourceFilePath) => {
       }
     } else {
       excerpt = `(${reResult[1]}) ${reResult[7]}`;
-      filePath = join(projectPath, reResult[5]);
+      filePath = ensureAbsolutePath(projectPath, reResult[5]);
       const fileEditor = findTextEditor(filePath);
       if (fileEditor) {
         range = generateRange(fileEditor, reResult[6] - 1);
@@ -181,7 +188,7 @@ const parseWarning = async (toParse, sourceFilePath) => {
   let reResult = re.exec(toParse);
 
   while (reResult != null) {
-    const filePath = join(projectPath, reResult[2]);
+    const filePath = ensureAbsolutePath(projectPath, reResult[2]);
     try {
       let range;
       const fileEditor = findTextEditor(filePath);
@@ -219,7 +226,7 @@ const parseLegacyWarning = async (toParse, sourceFilePath) => {
   const projectPath = await elixirProjectPath(sourceFilePath);
   let reResult = re.exec(toParse);
   while (reResult !== null) {
-    const filePath = join(projectPath, reResult[1]);
+    const filePath = ensureAbsolutePath(projectPath, reResult[1]);
     try {
       let range;
       const fileEditor = findTextEditor(filePath);


### PR DESCRIPTION
While debugging another issue, I encountered a problem whereby linter results were not being displayed in the editor.

After some some investigation, I noted that the paths coming from `elixirc` errors were absolute, whereas those coming from `mix compile` errors were relative. This was causing a problem with the construction of the `filePath` variable for the error message, as an assumption of relative paths was being made, and `join(projectPath, filePath)` was being used to construct an absolute path. This resulted in the project path being prepended to an already absolute path, and an invalid path was produced. The main linter code was unable to display the errors as they existed in "files" that simply didn't exist.

I've attempted to resolve this by importing the `isAbsolute()` function from the `path` module, and using it to determine if the path retrieved from the `mix` or `elixirc` error is already absolute. If it is absolute, then it is used directly; if it is relative then, and only then, is the project path prepended.