### PR TITLE
Force elixirc for umbrella projects

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -381,7 +381,8 @@ export default {
           isForcedElixirc() ||
             !(await isMixProject(filePath)) ||
             isExsFile(filePath) ||
-            (await isPhoenixProject(filePath))
+            (await isPhoenixProject(filePath)) ||
+            (await isUmbrellaProject(filePath))
         ) {
           return lintElixirc(textEditor);
         }


### PR DESCRIPTION
This PR tracks the changes for an intermediary resolution to the problems raised in Issue #96.

For now it's not possible to correctly determine the file path within an umbrella project that contains errors when using Mix (via `mix compile`). While a full solution is being sought, I've changed the conditional that determines which compiler path to take so that umbrella projects will always be compiled with `elixirc` instead of `mix compile`

It is not possible to add unit tests for this due to the limitations of performing Mix-based testing.