### PR TITLE
Fix lint failures for eslint-config-airbnb-base update

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -123,16 +123,16 @@ const parseError = async (toParse, sourceFilePath) => {
   const re = regexp(
     `
     \\*\\*[\\ ]+
-    \\((\\w+)\\)                   ${''/* 1 - (TypeOfError)*/}
-    [\\ ](?:                       ${''/* Two message formats.... mode one*/}
-      ([\\w\\ ]+)                  ${''/* 2 - Message*/}
-      [\\r\\n]{1,2}.+[\\r\\n]{1,2} ${''/* Internal elixir code*/}
-      [\\ ]+(.+)                   ${''/* 3 - File*/}
-      :(\\d+):                     ${''/* 4 - Line*/}
-    |                              ${''/* Or... mode two*/}
-      (.+)                         ${''/* 5 - File*/}
-      :(\\d+):                     ${''/* 6 - Line*/}
-      [\\ ](.+)                    ${''/* 7 - Message*/}
+    \\((\\w+)\\)                   ${''/* 1 - (TypeOfError) */}
+    [\\ ](?:                       ${''/* Two message formats.... mode one */}
+      ([\\w\\ ]+)                  ${''/* 2 - Message */}
+      [\\r\\n]{1,2}.+[\\r\\n]{1,2} ${''/* Internal elixir code */}
+      [\\ ]+(.+)                   ${''/* 3 - File */}
+      :(\\d+):                     ${''/* 4 - Line */}
+    |                              ${''/* Or... mode two */}
+      (.+)                         ${''/* 5 - File */}
+      :(\\d+):                     ${''/* 6 - Line */}
+      [\\ ](.+)                    ${''/* 7 - Message */}
     )
   `,
     'gm',


### PR DESCRIPTION
In issue #99 the Greenkeeper bot picked up failures due to an update to the `eslint-config-airbnb-base` package being updated. This PR resolves those linter failures.