### PR TITLE
Pin fs-extra to 4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "eslint": "^3.13.0",
     "eslint-config-airbnb-base": "^11.0.1",
     "eslint-plugin-import": "^2.2.0",
-    "fs-extra": "^4.0.0"
+    "fs-extra": "^4.0.1"
   },
   "eslintConfig": {
     "extends": "airbnb-base",


### PR DESCRIPTION
Issue #100 is failing after testing an update to 4.0.1 of `fs-extra`. Checking the tests shows that the failure is actually the linter issues from #99. Putting up this PR to run the 4.0.1 package through CI and verify that it is okay.