### PR TITLE
chore(package): update eslint to version 4.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "tmp": "^0.0.31"
   },
   "devDependencies": {
-    "eslint": "^3.13.0",
+    "eslint": "^4.3.0",
     "eslint-config-airbnb-base": "^11.0.1",
     "eslint-plugin-import": "^2.2.0",
     "fs-extra": "^3.0.1"


### PR DESCRIPTION
`peerDependencies` for `eslint-config-airbnb-base` (`eslint` == 4.3.0 and `eslint-plugin-import` == 2.7.0) are satisfied so this should be good to update now.

Closes #94