### PR TITLE
Fix minimum versions of devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "eslint": "^4.3.0",
-    "eslint-config-airbnb-base": "^11.0.1",
+    "eslint-config-airbnb-base": "^11.3.1",
     "eslint-plugin-import": "^2.2.0",
     "fs-extra": "^4.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "eslint": "^4.3.0",
     "eslint-config-airbnb-base": "^11.3.1",
-    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-import": "^2.7.0",
     "fs-extra": "^4.0.1"
   },
   "eslintConfig": {


### PR DESCRIPTION
`eslint-config-airbnb-base` needs to be v11.3.0 at minimum for ESLint v4 support, and `eslint-plugin-import` needs to be v2.7.0 for `eslint-config-airbnb-base`.